### PR TITLE
Implement predictor-corrector algorithm in adaptive mesh refinement

### DIFF
--- a/macro-heat.py
+++ b/macro-heat.py
@@ -44,8 +44,8 @@ def main():
 
     # Time related variables
     ns.dt = config.get_dt()
-    n = 0
-    t = 0
+    n = n_checkpoint = 0
+    t = t_checkpoint = 0
     dt = config.get_dt()
     t_end = config.get_total_time()
     n_end = int(t_end / dt)

--- a/micro-manager.py
+++ b/micro-manager.py
@@ -113,13 +113,12 @@ while interface.is_coupling_ongoing():
     k, phi = [], []
     i = 0
     for data in readData:
+        micro_sims[i].refine_mesh()
         phi_i = micro_sims[i].solve_allen_cahn(temperature=data, dt=dt)
         phi.append(phi_i)
 
         k_i = micro_sims[i].solve_heat_cell_problem()
         k.append(k_i)
-
-        micro_sims[i].refine_mesh()
 
         i += 1
 

--- a/micro_sim/micro_heat_circular.py
+++ b/micro_sim/micro_heat_circular.py
@@ -115,6 +115,9 @@ class MicroSimulation:
         self._solphinm1 = self._solphi_checkpoint
 
     def refine_mesh(self):
+        self._coarse_solphi = function.dotarg('solphi', self._topo_coarse.basis('std', degree=1))
+        sqrphi = self._topo.integral((self._coarse_solphi - self._solphi) ** 2, degree=2)
+        self._solphi = solver.optimize('solphi', sqrphi, droptol=1E-12)
         for level in range(self._ref_level):
             print("level = {}".format(level))
             smpl = self._topo_coarse.sample('uniform', 5)

--- a/micro_sim/micro_heat_circular.py
+++ b/micro_sim/micro_heat_circular.py
@@ -119,7 +119,7 @@ class MicroSimulation:
         """
         At the time of the calling of this function a predicted solution exists in ns.phi
         """
-        # Project predicted solution onto coarse mesh
+        # Project the current auxiliary solution onto coarse mesh
         coarse_solphi = function.dotarg('solphi', self._topo_coarse.basis('std', degree=1))
         sqrphi = self._topo.integral((coarse_solphi - self._ns.phi) ** 2, degree=2)
         solphi = solver.optimize('solphi', sqrphi, droptol=1E-12)
@@ -135,7 +135,7 @@ class MicroSimulation:
             topo_refined = topo_predicted.refined_by(np.unique(ielem[criterion]))
 
         # Create a projection topology which is the union of refined topologies of previous time step and the predicted
-        self._topo = self._topo.disjoint_union(self._topo, topo_refined)
+        self._topo = self._topo & topo_refined
 
         # Reinitialize the namespace according to the refined topology
         self.reinitialize_namespace()

--- a/micro_sim/micro_heat_circular.py
+++ b/micro_sim/micro_heat_circular.py
@@ -25,7 +25,6 @@ class MicroSimulation:
         # Set up mesh with periodicity in both X and Y directions
         self._topo, self._geom = mesh.rectilinear([np.linspace(-0.5, 0.5, self._nelems)] * 2, periodic=(0, 1))
         self._topo_coarse = self._topo  # Save original coarse topology to use to re-refinement
-        self._topo_nm1 = self._topo  # Topology of last time step
 
         self._ns = None  # Namespace is created after initial refinement
 
@@ -59,7 +58,7 @@ class MicroSimulation:
         self._solphinm1 = self._solphi  # At t = 0 the history data is same as the new data
 
         target_poro = 1 - math.pi * r**2
-        print("Target amount of sand material = {}".format(target_poro))
+        print("Target amount of void space = {}".format(target_poro))
 
         # Solve phase field problem for a few steps to get the correct phase field
         poro = 0
@@ -125,7 +124,7 @@ class MicroSimulation:
         solphi = solver.optimize('solphi', sqrphi, droptol=1E-12)
 
         # Refine the coarse mesh according to the predicted solution to get a predicted refined topology
-        topo_predicted = self._topo_coarse  # Set the predicted topology as the original coarse topology
+        topo_predicted = self._topo_coarse  # Set the predicted topology as the initial coarse topology
         for level in range(self._ref_level):
             print("level = {}".format(level))
             smpl = self._topo_coarse.sample('uniform', 5)
@@ -143,7 +142,7 @@ class MicroSimulation:
     def solve_allen_cahn(self, temperature, dt):
         """
         Solving the Allen-Cahn Equation using a Newton solver.
-        Returns ratio of grain and surrounding sand material for the micro domain
+        Returns porosity of the micro domain
         """
         resphi = self._topo.integral(
             '(lam^2 phibasis_n dphidt + gam phibasis_n ddwpdphi + gam lam^2 phibasis_n,i phi_,i + '

--- a/precice-config.xml
+++ b/precice-config.xml
@@ -48,8 +48,8 @@
 
     <coupling-scheme:parallel-implicit>
        <participants first="Macro-heat" second="Micro-manager"/>
-       <max-time value="1.0"/>
-       <time-window-size value="1.0e-2"/>
+       <max-time value="0.002"/>
+       <time-window-size value="1.0e-3"/>
        <max-iterations value="30"/>
        <exchange data="k_00" mesh="macro-mesh" from="Micro-manager" to="Macro-heat" initialize="yes"/>
        <exchange data="k_01" mesh="macro-mesh" from="Micro-manager" to="Macro-heat" initialize="yes"/>


### PR DESCRIPTION
This PR implements a predictor-corrector algorithm in the adaptive mesh refinement on the micro-scale. The algorithm is taken from the paper: [10.1016/j.amc.2020.125933](http://dx.doi.org/10.1016/j.amc.2020.125933)